### PR TITLE
fix send typespec

### DIFF
--- a/lib/exexec.ex
+++ b/lib/exexec.ex
@@ -146,7 +146,7 @@ defmodule Exexec do
 
   `pid` can be an `Exexec` pid or an OS pid.
   """
-  @spec send(pid | os_pid, binary) :: :ok
+  @spec send(pid | os_pid, binary | :eof) :: :ok
   defdelegate send(pid, data), to: :exec
 
   @doc """


### PR DESCRIPTION
The exec:send/2 function allows, in addition to binary data to send, an atom of
`eof` to close standard input.  The Exexec typespec did not reflect this,
though the Erlange `exec` module, does so here:

* https://github.com/saleyn/erlexec/blob/master/src/exec.erl#L464